### PR TITLE
Fix scheduled workflow push guard for default branch

### DIFF
--- a/.github/workflows/build_sched.yml
+++ b/.github/workflows/build_sched.yml
@@ -88,7 +88,9 @@ jobs:
           tail -n 30 _data/bhn_ncos_schedule.yml || true
 
       - name: Commit & push updated schedule
-        if: github.ref == 'refs/heads/main'
+        # Allow pushes on whichever branch triggered the workflow. Scheduled runs
+        # execute on the repository's default branch, which may not be "main".
+        if: startsWith(github.ref, 'refs/heads/')
         id: commit
         run: |
           set -e


### PR DESCRIPTION
## Summary
- allow the scheduled schedule-refresh workflow to push on whatever branch triggered it
- document the reason so the job still commits when the default branch is renamed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2f3be1c84833093abb4349a2a84ea