### PR TITLE
Clarify worldwide scope on Blind Hams etiquette page

### DIFF
--- a/nets/blind-hams/etiquette.md
+++ b/nets/blind-hams/etiquette.md
@@ -1,33 +1,34 @@
 ---
 layout: default
-title: Tips, Etiquette, and Code Of Conduct on the Blind Hams Digital Network
+title: Tips, Etiquette, and Code of Conduct on the Blind Hams Digital Network
 permalink: /nets/blind-hams/etiquette/
 ---
 
 # Operating Etiquette
-- The Blind Hams Digital Network strives to be friendly , accepting, and helpfuil to everyone. TRHough we are the Blind Hams Digital network, sighted people are welcome.  Ifyou have a license to operate on the ham bands, you are welcome on this network.
-##TL;DR (Too Long Didn't read? {#tldr}
+- The Blind Hams Digital Network strives to be friendly, accepting, and helpful to everyone. Though we are the Blind Hams Digital Network, sighted people are welcome. If you have a license to operate on the ham bands, you are welcome on this network.
+
+## TL;DR (Too Long Didn't Read) {#tldr}
 - **Be brief, clear, and courteous.**
 - **Listen first;** join when there’s a break.
 - **ID regularly** and use plain language.
-- **Make it accessible:** good mic technique, avoid overdriven audio, describe visuals, expand acronyms at first use. Remember that not everyone who connects is blind.
-- **Avoid heated topics** unless you are on an "anything goes" node i.e. Allstar node 506318 or another community hosted node)
-- Disagree kindly, not loudly. Remember that disagreement is inevitable, it's ok to agree to disagree, then move on to new topics. In short, **If things go sideways:** de-escalate, move on, or take it to a quieter channel, frequency, or mode.
+- **Make it accessible:** good mic technique, avoid overdriven audio, describe visuals, and expand acronyms at first use. Remember that not everyone who connects is blind.
+- **Avoid heated topics** unless you are on an "anything goes" node (e.g., AllStar node 506318 or another community-hosted node).
+- Disagree kindly, not loudly. Remember that disagreement is inevitable; it's OK to agree to disagree, then move on to new topics. In short, **if things go sideways:** de-escalate, move on, or take it to a quieter channel, frequency, or mode.
 - **During nets:** follow your net control operator's directions; limit side chats unless allowed to answer a net question and directed through net control. Pass traffic efficiently.
 
 ---
 
 ## Everyday Operation (most of the time)
 ### Be Considerate
-- Share the channel: keep overs concise; leave gaps for others. You may be able to speak at any time and hear others (full duplex), but many nodes are simplex, and thus may have a hard time to get a word in edgewise.
-- Identify when you first join a conversation and at appropriate intervals as required  by your amateur radio license.
+- Share the channel: keep overs concise; leave gaps for others. You may be able to speak at any time and hear others (full duplex), but many nodes are simplex and may have a hard time getting a word in edgewise.
+- Identify when you first join a conversation and at appropriate intervals as required by your amateur radio license.
 
 ### Be Clear
-- Use plain language. Be prepared to explain jargon and expand acronyms (e.g., in case new hams and non-amateurs are listening.
+- Use plain language. Be prepared to explain jargon and expand acronyms (e.g., in case new hams and non-amateurs are listening).
 
-### Be Calm, cool,. and collected
-- We’re are worldwide. Technical debates are fine; **don’t make it personal**.
-- Sensitive or political topics are allowed, consider the content and discussed. If it’s straying into uncomfortable territory or culturally related topics, remember others. Sometimes, consider trying to steer the conversation back to ham radio tips or move the convo elsewhere.
+### Be Calm, Cool, and Collected
+- We are a worldwide network. Technical debates are fine; **don’t make it personal**.
+- Sensitive or political topics are allowed; consider the content and context. If the conversation strays into uncomfortable or culturally sensitive territory, remember others. When possible, steer the discussion back to ham radio tips or move the conversation elsewhere.
 
 ---
 
@@ -40,7 +41,7 @@ permalink: /nets/blind-hams/etiquette/
 - No side QSOs on the net channel.
 
 ### If You’re Net Control (NCO)
-- Open with a general QST, the net name, purpose, time, ) and instructions that are relevant to your net.
+- Open with a general QST, the net name, purpose, time, and any instructions that are relevant to your net.
 - Set expectations (round-table, one item, time limit).
 - Keep a steady pace; rotate fairly; summarize outcomes when helpful.
 - Close with thanks, next-net info, and any follow-ups.
@@ -52,8 +53,9 @@ permalink: /nets/blind-hams/etiquette/
 - **Personal attacks, harassment, or slurs.** Zero tolerance.
 - **Interference on purpose** (jamming, kerchunking, tuning up on top of people).
 - **Publishing private info** without consent.
-- **Content that breaks law or license terms.** 
-an admin or NCO may warn, mute, or remove to keep the space safe.
+- **Content that breaks law or license terms.**
+
+An admin or NCO may warn, mute, or remove to keep the space safe.
 
 ## When There’s Disagreement
 
@@ -82,4 +84,4 @@ This page will evolve as our community grows. Suggestions? Corrections? Please c
 - For full connection instructions (AllStar, EchoLink, DMR, D‑STAR, YSF, Alexa), see the
   <a href="/nets/blind-hams/connect/">How to Connect</a> page.
 
-**73 and thank you for being a considerate operator.** Welcome to the network!!
+**73 and thank you for being a considerate operator.** Welcome to the network!


### PR DESCRIPTION
## Summary
- clarify that the Blind Hams Digital Network is a worldwide network
- smooth out language around sensitive-topic discussions for readability

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68e486504df88330bdaf496cb6630633